### PR TITLE
inserting information clues in links.txt

### DIFF
--- a/links.txt
+++ b/links.txt
@@ -1,2 +1,4 @@
 http://www.bbc.co.uk/news/technology-43650215
+@@"www.bbc.co.uk/news/technology-43650215"
 https://www.theguardian.com/technology/2018/apr/11/zuckerberg-hearing-facebook-tracking-questions-house-back-foot
+@@"www.theguardian.com/technology/2018/apr/11/zuckerberg-hearing-facebook-tracking-questions-house-back-foot"


### PR DESCRIPTION
These information lines would help at separating the information in the unified json file according to their originators. I propose the actual format but it can be really anything that wouln't trigger citron to look for information. Keeping the same separation clue - as in "www" from the links- would help towards automation of the information processing.